### PR TITLE
Fix install issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 setup(
@@ -9,4 +9,5 @@ setup(
     author_email='eric.hutton@colorado.edu',
     url='https://github.com/csdms/py_scripting',
     description='Python scripting utilities',
+    packages=find_packages(),
 )


### PR DESCRIPTION
Installing the package with*

    python setup.py install

seemed to work, in that `setup` ran to completion, but when I tried to import the `scripting` package into a Python session, it failed. Using `find_packages` fixes this.

*Note that installing the package with

    python setup.py develop

worked just fine.